### PR TITLE
Fix error : sometimes api/encoder start before rabbitmq

### DIFF
--- a/docker/docker-compose-external.yml
+++ b/docker/docker-compose-external.yml
@@ -41,7 +41,7 @@ services:
     logging:
       *default-logging
     healthcheck:
-      test: rabbitmq-diagnostics -q ping
+      test: rabbitmq-diagnostics -q alarms
       interval: 30s
       timeout: 30s
       retries: 3


### PR DESCRIPTION
Sometimes, api and/or encoder services start before rabbitmq serivce is fully operational.
Following the [rabbitmq doc](https://www.rabbitmq.com/monitoring.html#health-checks), I increased the healthcheck "Stage".