### PR TITLE
Remove memory limit increase for dev

### DIFF
--- a/.github/workflows/CI-CD.yml
+++ b/.github/workflows/CI-CD.yml
@@ -271,8 +271,6 @@ jobs:
                 "image_user": "${{ secrets.DOCKER_USER }}",
                 "image_password": "${{ secrets.DOCKER_TOKEN }}",
                 "instances": "1",
-                "limit_cpu": "1000",
-                "limit_memory": "512",
                 "env": {
                   "S3_AUTH_KEY": "${{ secrets.S3_AUTH_KEY }}",
                   "S3_AUTH_PWD": "${{ secrets.S3_AUTH_PWD }}",


### PR DESCRIPTION
I tried to give 512mb of RAM for encoder. But it's too much with 6 running services. Note that the default value on Sqsc is 256mb. And remember that we cannot create more than 6 services with 256mb of memory with the dev infra.